### PR TITLE
Add support for browsers without Date.now

### DIFF
--- a/lib/ServerDate.js
+++ b/lib/ServerDate.js
@@ -23,6 +23,11 @@ along with ServerDate.  If not, see <http://www.gnu.org/licenses/>.
 
 'use strict';
 
+//Date.now support for older browsers
+if (!Date.now) {
+    Date.now = function() { return new Date().getTime(); }
+}
+
 var ServerDate = (function(serverNow) {
 // This is the first time we align with the server's clock by using the time
 // this script was generated (serverNow) and noticing the client time before


### PR DESCRIPTION
ServerDate assumes the existence of Date.now, this adds a shim in case it doesn't exist.