### PR TITLE
Send a HEAD request instead of GET

### DIFF
--- a/lib/ServerDate.js
+++ b/lib/ServerDate.js
@@ -182,7 +182,7 @@ function synchronize() {
 
     // Ask the server for another copy of ServerDate.js but specify a unique number on the URL querystring
 	// so that we don't get the browser cached Javascript file
-	request.open("GET", URL + "?noCache=" + Date.now());
+	request.open("HEAD", URL + "?noCache=" + Date.now());
 
     // At the earliest possible moment of the response, record the time at
     // which we received it.


### PR DESCRIPTION
Sending a HEAD request will tell the server you're not actually interested in the asset's content. In this case, you're doing nothing with the actual JavaScript you're pulling back. For users where bandwidth is particularly important. For some reason it syncs twice on page load, so using GET is about 82.5KB, compared to 12.3KB when using HEAD (over 21 requests).

Just some food for thought!